### PR TITLE
Remove deprecations in Atom 1.3

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,10 +1,9 @@
-atom-text-editor, atom-text-editor .gutter,
-:host, :host .gutter {
+atom-text-editor, atom-text-editor .gutter {
   background-color: #2b303b;
   color: #c0c5ce;
 }
 
-atom-text-editor, :host {
+atom-text-editor {
   .indent-guide {
     color: rgba(255, 255, 255, 0.1);
   }
@@ -14,204 +13,200 @@ atom-text-editor, :host {
   }
 }
 
-atom-text-editor.is-focused .cursor,
-:host(.is-focused) .cursor  {
+atom-text-editor.is-focused .cursor {
   border-color: #c0c5ce;
 }
 
-atom-text-editor.is-focused .selection .region,
-:host(.is-focused) .selection .region {
+atom-text-editor.is-focused .selection .region {
   background-color: #4f5b66;
 }
 
-atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line,
-:host(.is-focused) .line-number.cursor-line-no-selection, :host(.is-focused) .line.cursor-line {
+atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line {
   background-color: rgba(52, 61, 70, 0.5);
 }
 
-atom-text-editor .invisible-character,
-:host .invisible-character {
+atom-text-editor .invisible-character {
   color: rgba(192, 197, 206, 0.1);
 }
 
-.variable.parameter.function {
+.syntax--variable.syntax--parameter.syntax--function {
   color: #c0c5ce;
 }
 
-.comment, .punctuation.definition.comment {
+.syntax--comment, .syntax--punctuation.syntax--definition.syntax--comment {
   font-style: italic;
   color: #65737e;
 }
 
-.punctuation.definition.string, .punctuation.definition.variable, .punctuation.definition.string, .punctuation.definition.parameters, .punctuation.definition.string, .punctuation.definition.array {
+.syntax--punctuation.syntax--definition.syntax--string, .syntax--punctuation.syntax--definition.syntax--variable, .syntax--punctuation.syntax--definition.syntax--string, .syntax--punctuation.syntax--definition.syntax--parameters, .syntax--punctuation.syntax--definition.syntax--string, .syntax--punctuation.syntax--definition.syntax--array {
   color: #c0c5ce;
 }
 
-.none {
+.syntax--none {
   color: #c0c5ce;
 }
 
-.keyword.operator {
+.syntax--keyword.syntax--operator {
   color: #c0c5ce;
 }
 
-.keyword {
+.syntax--keyword {
   color: #b48ead;
 }
 
-.variable {
+.syntax--variable {
   color: #bf616a;
 }
 
-.entity.name.function, .meta.require, .support.function.any-method {
+.syntax--entity.syntax--name.syntax--function, .syntax--meta.syntax--require, .syntax--support.syntax--function.syntax--any-method {
   color: #8fa1b3;
 }
 
-.support.class, .entity.name.class, .entity.name.type.class {
+.syntax--support.syntax--class, .syntax--entity.syntax--name.syntax--class, .syntax--entity.syntax--name.syntax--type.syntax--class {
   color: #ebcb8b;
 }
 
-.meta.class {
+.syntax--meta.syntax--class {
   color: #eff1f5;
 }
 
-.keyword.other.special-method {
+.syntax--keyword.syntax--other.syntax--special-method {
   color: #8fa1b3;
 }
 
-.storage {
+.syntax--storage {
   color: #b48ead;
 }
 
-.support.function {
+.syntax--support.syntax--function {
   color: #96b5b4;
 }
 
-.string, .constant.other.symbol, .entity.other.inherited-class {
+.syntax--string, .syntax--constant.syntax--other.syntax--symbol, .syntax--entity.syntax--other.syntax--inherited-class {
   color: #a3be8c;
 }
 
-.constant.numeric {
+.syntax--constant.syntax--numeric {
   color: #d08770;
 }
 
-.none {
+.syntax--none {
   color: #d08770;
 }
 
-.none {
+.syntax--none {
   color: #d08770;
 }
 
-.constant {
+.syntax--constant {
   color: #d08770;
 }
 
-.entity.name.tag {
+.syntax--entity.syntax--name.syntax--tag {
   color: #bf616a;
 }
 
-.entity.other.attribute-name {
+.syntax--entity.syntax--other.syntax--attribute-name {
   color: #d08770;
 }
 
-.entity.other.attribute-name.id, .punctuation.definition.entity {
+.syntax--entity.syntax--other.syntax--attribute-name.syntax--id, .syntax--punctuation.syntax--definition.syntax--entity {
   color: #8fa1b3;
 }
 
-.meta.selector {
+.syntax--meta.syntax--selector {
   color: #b48ead;
 }
 
-.none {
+.syntax--none {
   color: #d08770;
 }
 
-.markup.heading .punctuation.definition.heading, .entity.name.section {
+.syntax--markup.syntax--heading .syntax--punctuation.syntax--definition.syntax--heading, .syntax--entity.syntax--name.syntax--section {
   color: #8fa1b3;
 }
 
-.keyword.other.unit {
+.syntax--keyword.syntax--other.syntax--unit {
   color: #d08770;
 }
 
-.markup.bold, .punctuation.definition.bold {
+.syntax--markup.syntax--bold, .syntax--punctuation.syntax--definition.syntax--bold {
   font-weight: bold;
   color: #ebcb8b;
 }
 
-.markup.italic, .punctuation.definition.italic {
+.syntax--markup.syntax--italic, .syntax--punctuation.syntax--definition.syntax--italic {
   font-style: italic;
   color: #b48ead;
 }
 
-.markup.raw.inline {
+.syntax--markup.syntax--raw.syntax--inline {
   color: #a3be8c;
 }
 
-.string.other.link {
+.syntax--string.syntax--other.syntax--link {
   color: #bf616a;
 }
 
-.meta.link {
+.syntax--meta.syntax--link {
   color: #d08770;
 }
 
-.markup.list {
+.syntax--markup.syntax--list {
   color: #bf616a;
 }
 
-.markup.quote {
+.syntax--markup.syntax--quote {
   color: #d08770;
 }
 
-.meta.separator {
+.syntax--meta.syntax--separator {
   color: #c0c5ce;
   background-color: #4f5b66;
 }
 
-.markup.inserted, .markup.inserted.git_gutter {
+.syntax--markup.syntax--inserted, .syntax--markup.syntax--inserted.git_gutter {
   color: #a3be8c;
 }
 
-.markup.deleted, .markup.deleted.git_gutter {
+.syntax--markup.syntax--deleted, .syntax--markup.syntax--deleted.git_gutter {
   color: #bf616a;
 }
 
-.markup.changed, .markup.changed.git_gutter {
+.syntax--markup.syntax--changed, .syntax--markup.syntax--changed.git_gutter {
   color: #b48ead;
 }
 
-.markup.ignored, .markup.ignored.git_gutter {
+.syntax--markup.syntax--ignored, .syntax--markup.syntax--ignored.git_gutter {
   color: #4f5b66;
 }
 
-.markup.untracked, .markup.untracked.git_gutter {
+.syntax--markup.untracked, .syntax--markup.untracked.git_gutter {
   color: #4f5b66;
 }
 
-.constant.other.color {
+.syntax--constant.syntax--other.syntax--color {
   color: #96b5b4;
 }
 
-.string.regexp {
+.syntax--string.syntax--regexp {
   color: #96b5b4;
 }
 
-.constant.character.escape {
+.syntax--constant.syntax--character.syntax--escape {
   color: #96b5b4;
 }
 
-.punctuation.section.embedded, .variable.interpolation {
+.syntax--punctuation.syntax--section.syntax--embedded, .syntax--variable.syntax--interpolation {
   color: #ab7967;
 }
 
-.invalid.illegal {
+.syntax--invalid.syntax--illegal {
   color: #2b303b;
   background-color: #bf616a;
 }
 
-.tree-view-resizer, atom-text-editor, :host {
+.tree-view-resizer, atom-text-editor {
   ::-webkit-scrollbar {
     width: 1em;
     height: 1em;


### PR DESCRIPTION
This was all done with find/replace and eyeballing it quickly so there could be possible errors. I know there doesn't seem to be much going on with this theme but if anyone needs the updates here they are. Basically :host/:shadow pseudo selectors are removed and add syntax-- before any syntax styling.

Here is the original deprecation message from Atom.

```
Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--. To prevent breakage with existing style sheets, Atom will automatically upgrade the following selectors:

atom-text-editor, atom-text-editor .gutter, :host, :host .gutter => atom-text-editor, atom-text-editor .gutter,atom-text-editor,atom-text-editor .gutter
atom-text-editor .indent-guide, :host .indent-guide => atom-text-editor .indent-guide,atom-text-editor .indent-guide
atom-text-editor .wrap-guide, :host .wrap-guide => atom-text-editor .wrap-guide,atom-text-editor .wrap-guide
atom-text-editor.is-focused .cursor, :host(.is-focused) .cursor => atom-text-editor.is-focused .cursor,atom-text-editor .cursor
atom-text-editor.is-focused .selection .region, :host(.is-focused) .selection .region => atom-text-editor.is-focused .selection .region,atom-text-editor .selection .region
atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line, :host(.is-focused) .line-number.cursor-line-no-selection, :host(.is-focused) .line.cursor-line => atom-text-editor.is-focused .line-number.cursor-line-no-selection, atom-text-editor.is-focused .line.cursor-line,atom-text-editor .line-number.cursor-line-no-selection,atom-text-editor .line.cursor-line
atom-text-editor .invisible-character, :host .invisible-character => atom-text-editor .invisible-character,atom-text-editor .invisible-character
.variable.parameter.function => .syntax--variable.syntax--parameter.syntax--function
.comment, .punctuation.definition.comment => .syntax--comment, .syntax--punctuation.syntax--definition.syntax--comment
.punctuation.definition.string, .punctuation.definition.variable, .punctuation.definition.string, .punctuation.definition.parameters, .punctuation.definition.string, .punctuation.definition.array => .syntax--punctuation.syntax--definition.syntax--string, .syntax--punctuation.syntax--definition.syntax--variable, .syntax--punctuation.syntax--definition.syntax--string, .syntax--punctuation.syntax--definition.syntax--parameters, .syntax--punctuation.syntax--definition.syntax--string, .syntax--punctuation.syntax--definition.syntax--array
.none => .syntax--none
.keyword.operator => .syntax--keyword.syntax--operator
.keyword => .syntax--keyword
.variable => .syntax--variable
.entity.name.function, .meta.require, .support.function.any-method => .syntax--entity.syntax--name.syntax--function, .syntax--meta.syntax--require, .syntax--support.syntax--function.syntax--any-method
.support.class, .entity.name.class, .entity.name.type.class => .syntax--support.syntax--class, .syntax--entity.syntax--name.syntax--class, .syntax--entity.syntax--name.syntax--type.syntax--class
.meta.class => .syntax--meta.syntax--class
.keyword.other.special-method => .syntax--keyword.syntax--other.syntax--special-method
.storage => .syntax--storage
.support.function => .syntax--support.syntax--function
.string, .constant.other.symbol, .entity.other.inherited-class => .syntax--string, .syntax--constant.syntax--other.syntax--symbol, .syntax--entity.syntax--other.syntax--inherited-class
.constant.numeric => .syntax--constant.syntax--numeric
.none => .syntax--none
.none => .syntax--none
.constant => .syntax--constant
.entity.name.tag => .syntax--entity.syntax--name.syntax--tag
.entity.other.attribute-name => .syntax--entity.syntax--other.syntax--attribute-name
.entity.other.attribute-name.id, .punctuation.definition.entity => .syntax--entity.syntax--other.syntax--attribute-name.syntax--id, .syntax--punctuation.syntax--definition.syntax--entity
.meta.selector => .syntax--meta.syntax--selector
.none => .syntax--none
.markup.heading .punctuation.definition.heading, .entity.name.section => .syntax--markup.syntax--heading .syntax--punctuation.syntax--definition.syntax--heading, .syntax--entity.syntax--name.syntax--section
.keyword.other.unit => .syntax--keyword.syntax--other.syntax--unit
.markup.bold, .punctuation.definition.bold => .syntax--markup.syntax--bold, .syntax--punctuation.syntax--definition.syntax--bold
.markup.italic, .punctuation.definition.italic => .syntax--markup.syntax--italic, .syntax--punctuation.syntax--definition.syntax--italic
.markup.raw.inline => .syntax--markup.syntax--raw.syntax--inline
.string.other.link => .syntax--string.syntax--other.syntax--link
.meta.link => .syntax--meta.syntax--link
.markup.list => .syntax--markup.syntax--list
.markup.quote => .syntax--markup.syntax--quote
.meta.separator => .syntax--meta.syntax--separator
.markup.inserted, .markup.inserted.git_gutter => .syntax--markup.syntax--inserted, .syntax--markup.syntax--inserted.git_gutter
.markup.deleted, .markup.deleted.git_gutter => .syntax--markup.syntax--deleted, .syntax--markup.syntax--deleted.git_gutter
.markup.changed, .markup.changed.git_gutter => .syntax--markup.syntax--changed, .syntax--markup.syntax--changed.git_gutter
.markup.ignored, .markup.ignored.git_gutter => .syntax--markup.syntax--ignored, .syntax--markup.syntax--ignored.git_gutter
.markup.untracked, .markup.untracked.git_gutter => .syntax--markup.untracked, .syntax--markup.untracked.git_gutter
.constant.other.color => .syntax--constant.syntax--other.syntax--color
.string.regexp => .syntax--string.syntax--regexp
.constant.character.escape => .syntax--constant.syntax--character.syntax--escape
.punctuation.section.embedded, .variable.interpolation => .syntax--punctuation.syntax--section.syntax--embedded, .syntax--variable.syntax--interpolation
.invalid.illegal => .syntax--invalid.syntax--illegal
.tree-view-resizer ::-webkit-scrollbar, atom-text-editor ::-webkit-scrollbar, :host ::-webkit-scrollbar => .tree-view-resizer ::-webkit-scrollbar, atom-text-editor ::-webkit-scrollbar,atom-text-editor ::-webkit-scrollbar
.tree-view-resizer ::-webkit-scrollbar-corner, atom-text-editor ::-webkit-scrollbar-corner, :host ::-webkit-scrollbar-corner, .tree-view-resizer ::-webkit-scrollbar-track, atom-text-editor ::-webkit-scrollbar-track, :host ::-webkit-scrollbar-track => .tree-view-resizer ::-webkit-scrollbar-corner, atom-text-editor ::-webkit-scrollbar-corner,atom-text-editor ::-webkit-scrollbar-corner, .tree-view-resizer ::-webkit-scrollbar-track, atom-text-editor ::-webkit-scrollbar-track,atom-text-editor ::-webkit-scrollbar-track
.tree-view-resizer ::-webkit-scrollbar-thumb, atom-text-editor ::-webkit-scrollbar-thumb, :host ::-webkit-scrollbar-thumb => .tree-view-resizer ::-webkit-scrollbar-thumb, atom-text-editor ::-webkit-scrollbar-thumb,atom-text-editor ::-webkit-scrollbar-thumb
Automatic translation of selectors will be removed in a few release cycles to minimize startup time. Please, make sure to upgrade the above selectors as soon as possible.
```